### PR TITLE
add encode before hasing key source

### DIFF
--- a/budou/budou.py
+++ b/budou/budou.py
@@ -130,7 +130,7 @@ class Budou(object):
     """Returns a cache key for the given source and class name."""
     key_source = '%s:%s:%s' % (
         CACHE_SALT, source.encode('utf8'), classname.encode('utf8'))
-    return hashlib.md5(key_source).hexdigest()
+    return hashlib.md5(key_source.encode()).hexdigest()
 
 
   def _get_annotations(self, text, encoding='UTF32'):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 
 setup(
     name='budou',
-    version='0.1.1',
+    version='0.1.2',
     author='Shuhei Iitsuka',
     author_email='tushuhei@google.com',
     description='CJK Line Break Organizer',


### PR DESCRIPTION
```
File "/path/to/lib/python3.5/site-packages/budou/budou.py", line 106, in parse
    cache_key = self._get_cache_key(source, classname)
  File "/path/to/lib/python3.5/site-packages/budou/budou.py", line 133, in _get_cache_key
    return hashlib.md5(key_source).hexdigest()
TypeError: Unicode-objects must be encoded before hashing
```
this error happens in ver 0.1.1