### PR TITLE
Add attributes arg to control the DOM attributes.

### DIFF
--- a/budou/__init__.py
+++ b/budou/__init__.py
@@ -19,9 +19,11 @@ from .budou import Chunk
 from .budou import Element
 from .budou import HTML_POS
 from .budou import TARGET_LABEL
+from .budou import DEFAULT_CLASS_NAME
 
 authenticate = Budou.authenticate
 Chunk = Chunk
 Element = Element
 HTML_POS = HTML_POS
 TARGET_LABEL = TARGET_LABEL
+DEFAULT_CLASS_NAME = DEFAULT_CLASS_NAME

--- a/budou/budou.py
+++ b/budou/budou.py
@@ -27,6 +27,7 @@ from oauth2client.client import GoogleCredentials
 import oauth2client.service_account
 import re
 import shelve
+import six
 
 Chunk = collections.namedtuple('Chunk', ['word', 'pos', 'label', 'forward'])
 """Word chunk object.
@@ -151,7 +152,7 @@ class Budou(object):
     Returns:
       A dictionary.
     """
-    if attributes and isinstance(attributes, basestring):
+    if attributes and isinstance(attributes, six.string_types):
       return {
           'class': attributes
       }
@@ -308,8 +309,9 @@ class Budou(object):
       if chunk.pos == SPACE_POS:
         result.append(chunk.word)
       else:
-        result.append(etree.tostring(
-            maker.span(chunk.word, attributes), encoding='utf8').decode('utf8'))
+        element = etree.Element('span', collections.OrderedDict(attributes))
+        element.text = chunk.word
+        result.append(etree.tostring(element, encoding='utf8').decode('utf8'))
     return ''.join(result)
 
   def _concatenate_punctuations(self, chunks):

--- a/budou/budou.py
+++ b/budou/budou.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,17 +16,17 @@
 
 """Budou, an automatic CJK line break organizer."""
 
-import cgi
 import collections
 from googleapiclient import discovery
+import hashlib
 import httplib2
 from lxml import etree
 from lxml import html
+from lxml.builder import ElementMaker
 from oauth2client.client import GoogleCredentials
 import oauth2client.service_account
 import re
 import shelve
-import hashlib
 
 Chunk = collections.namedtuple('Chunk', ['word', 'pos', 'label', 'forward'])
 """Word chunk object.
@@ -67,12 +69,13 @@ class Budou(object):
   @classmethod
   def authenticate(cls, json_path=None):
     """Authenticates user for Cloud Natural Language API and returns the parser.
+
     If the credential file path is not given, this tries to generate credentials
     from default settings.
 
     Args:
-      json_path: A file path to a credential JSON file for a Google Cloud Project
-      which Cloud Natural Language API is enabled (string, optional).
+      json_path: A file path to a credential JSON file for a Google Cloud
+      Project which Cloud Natural Language API is enabled (string, optional).
 
     Returns:
       Budou module.
@@ -90,22 +93,29 @@ class Budou(object):
     service = discovery.build('language', 'v1beta1', http=http)
     return cls(service)
 
-  def parse(self, source, classname=DEFAULT_CLASS_NAME, use_cache=True,
-            language=''):
+  def parse(self, source, attributes=None, use_cache=True, language='',
+            classname=DEFAULT_CLASS_NAME):
     """Parses input HTML code into word chunks and organized code.
 
     Args:
       source: HTML code to be processed (unicode).
-      classname: A class name of each word chunk in the HTML code (string).
-      user_cache: Whether to use cache (boolean).
-      language: A language used to parse text (string).
+      attributes: If a dictionary, then a map of name-value pairs for attributes
+      of output SPAN tags. If a string, then this is the class name of output
+      SPAN tags. If an array, the elements will be joined together as the class
+      name of SPAN tags (dictionary|string, optional).
+      use_cache: Whether to use cache (boolean, optional).
+      language: A language used to parse text (string, optional).
+      classname: A class name of output SPAN tags (string, optional).
+      **This argument is deprecated. Please use attributes arg instead.
+      When specified with the attributes arg, the class name in the attributes
+      arg will be used.**
 
     Returns:
       A dictionary with the list of word chunks and organized HTML code.
     """
     if use_cache:
       cache_shelve = shelve.open(CACHE_FILE_NAME)
-      cache_key = self._get_cache_key(source, classname)
+      cache_key = self._get_cache_key(source, language)
       result_value = cache_shelve.get(cache_key, None)
       cache_shelve.close()
       if result_value: return result_value
@@ -117,7 +127,8 @@ class Budou(object):
     chunks = self._concatenate_by_label(chunks, True)
     chunks = self._concatenate_by_label(chunks, False)
     chunks = self._migrate_html(chunks, dom)
-    html_code = self._spanize(chunks, classname)
+    attributes = self._get_attribute_dict(attributes, classname)
+    html_code = self._spanize(chunks, attributes)
     result_value = {
         'chunks': chunks,
         'html_code': html_code
@@ -128,11 +139,33 @@ class Budou(object):
       cache_shelve.close()
     return result_value
 
+  def _get_attribute_dict(self, attributes, classname=None):
+    """Returns a dictionary of attribute name-value pairs.
+
+    Args:
+      attributes: If a dictionary, then a map of name-value pairs for attributes
+      of output SPAN tags. If a string, then this is the class name of output
+      SPAN tags (dictionary|string).
+      classname: Optional class name (string, optional).
+
+    Returns:
+      A dictionary.
+    """
+    if attributes and isinstance(attributes, basestring):
+      return {
+          'class': attributes
+      }
+    if not attributes:
+      attributes = {}
+    if not classname:
+      classname = DEFAULT_CLASS_NAME
+    attributes.setdefault('class', classname)
+    return attributes
+
   def _get_cache_key(self, source, classname):
     """Returns a cache key for the given source and class name."""
     key_source = u'%s:%s:%s' % (CACHE_SALT, source, classname)
     return hashlib.md5(key_source.encode('utf8')).hexdigest()
-
 
   def _get_annotations(self, text, language='', encoding='UTF32'):
     """Returns the list of annotations from the given text."""
@@ -148,7 +181,7 @@ class Budou(object):
     }
 
     if language:
-        body['document']['language'] = language
+      body['document']['language'] = language
 
     request = self.service.documents().annotateText(body=body)
     response = request.execute()
@@ -256,23 +289,27 @@ class Budou(object):
       if element.tail: index += len(element.tail)
     return result
 
-  def _spanize(self, chunks, classname):
+  def _spanize(self, chunks, attributes):
     """Returns concatenated HTML code with SPAN tag.
 
     Args:
       chunks: The list of word chunks.
-      classname: The class name of SPAN tags.
+      attributes: If a dictionary, then a map of name-value pairs for attributes
+      of output SPAN tags. If a string, then this is the class name of output
+      SPAN tags. If an array, the elements will be joined together as the
+      class name of SPAN tags.
 
     Returns:
       The organized HTML code.
     """
+    maker = ElementMaker()
     result = []
     for chunk in chunks:
       if chunk.pos == SPACE_POS:
         result.append(chunk.word)
       else:
-        result.append(u'<span class="%s">%s</span>'%(
-            cgi.escape(classname, quote=True), chunk.word))
+        result.append(etree.tostring(
+            maker.span(chunk.word, attributes), encoding='utf8').decode('utf8'))
     return ''.join(result)
 
   def _concatenate_punctuations(self, chunks):

--- a/budou/budou.py
+++ b/budou/budou.py
@@ -22,7 +22,6 @@ import hashlib
 import httplib2
 from lxml import etree
 from lxml import html
-from lxml.builder import ElementMaker
 from oauth2client.client import GoogleCredentials
 import oauth2client.service_account
 import re
@@ -303,15 +302,14 @@ class Budou(object):
     Returns:
       The organized HTML code.
     """
-    maker = ElementMaker()
     result = []
     for chunk in chunks:
       if chunk.pos == SPACE_POS:
         result.append(chunk.word)
       else:
-        element = etree.Element('span', collections.OrderedDict(attributes))
-        element.text = chunk.word
-        result.append(etree.tostring(element, encoding='utf8').decode('utf8'))
+        attribute_str = ' '.join(
+            '%s="%s"' % (k, v) for k, v in sorted(attributes.items()))
+        result.append('<span %s>%s</span>' % (attribute_str, chunk.word))
     return ''.join(result)
 
   def _concatenate_punctuations(self, chunks):

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'google-api-python-client',
         'oauth2client',
         'lxml==3.6.1',
+        'six',
     ],
     scripts=[
         'budou/budou.py',

--- a/test/budou_test.py
+++ b/test/budou_test.py
@@ -92,8 +92,8 @@ class TestBudouMethods(unittest.TestCase):
     ]
 
     expected_html_code = (
-        u'<span class="text-chunk" aria-describedby="parent">今日は</span>'
-        u'<span class="text-chunk" aria-describedby="parent">晴れ。</span>')
+        u'<span aria-describedby="parent" class="text-chunk">今日は</span>'
+        u'<span aria-describedby="parent" class="text-chunk">晴れ。</span>')
 
     result = self.parser.parse(DEFAULT_SENTENCE, {
         'aria-describedby': 'parent',

--- a/test/budou_test.py
+++ b/test/budou_test.py
@@ -60,6 +60,7 @@ class TestBudouMethods(unittest.TestCase):
     pass
 
   def test_process(self):
+    """Demonstrates standard usage."""
     expected_chunks = [
         budou.Chunk(u'今日は', u'NOUN', u'NN', True),
         budou.Chunk(u'晴れ。', u'NOUN', u'ROOT', False)
@@ -68,7 +69,36 @@ class TestBudouMethods(unittest.TestCase):
     expected_html_code = (u'<span class="ww">今日は</span>'
                           u'<span class="ww">晴れ。</span>')
 
-    result = self.parser.parse(DEFAULT_SENTENCE)
+    result = self.parser.parse(DEFAULT_SENTENCE, use_cache=False)
+
+    self.assertIn(
+        'chunks', result,
+        'Processed result should include chunks.')
+    self.assertIn(
+        'html_code', result,
+        'Processed result should include organized html code.')
+    self.assertEqual(
+        expected_chunks, result['chunks'],
+        'Processed result should include expected chunks.')
+    self.assertEqual(
+        expected_html_code, result['html_code'],
+        'Processed result should include expected html code.')
+
+  def test_process_with_aria(self):
+    """Demonstrates advanced usage considering accessibility."""
+    expected_chunks = [
+        budou.Chunk(u'今日は', u'NOUN', u'NN', True),
+        budou.Chunk(u'晴れ。', u'NOUN', u'ROOT', False)
+    ]
+
+    expected_html_code = (
+        u'<span class="text-chunk" aria-describedby="parent">今日は</span>'
+        u'<span class="text-chunk" aria-describedby="parent">晴れ。</span>')
+
+    result = self.parser.parse(DEFAULT_SENTENCE, {
+        'aria-describedby': 'parent',
+        'class': 'text-chunk'
+        }, use_cache=False)
 
     self.assertIn(
         'chunks', result,
@@ -139,12 +169,14 @@ class TestBudouMethods(unittest.TestCase):
         budou.Chunk(u'b', None, None, None),
         budou.Chunk(u'c', None, None, None),
     ]
-    classname = 'foo'
+    attributes = {
+        'class': 'foo'
+    }
     expected = (
         u'<span class="foo">a</span>'
         '<span class="foo">b</span>'
         '<span class="foo">c</span>')
-    result = self.parser._spanize(chunks, classname)
+    result = self.parser._spanize(chunks, attributes)
     self.assertEqual(
         result, expected,
         'The chunks should be compiled to a HTML code.')
@@ -188,6 +220,66 @@ class TestBudouMethods(unittest.TestCase):
         result, expected_backward_concat,
         'Backward directional chunks should be concatenated to preceding '
         'chunks.')
+
+  def test_get_attribute_dict(self):
+    result = self.parser._get_attribute_dict({})
+    self.assertEqual(
+        result, {'class': budou.DEFAULT_CLASS_NAME},
+        'When attributes is none and classname is not provided, the output '
+        'should have the default class name in it.')
+
+    result = self.parser._get_attribute_dict('foo')
+    self.assertEqual(
+        result, {'class': 'foo'},
+        'When attributes is a string and classname is not provided, the output '
+        'should have the specified class name in it.')
+
+    result = self.parser._get_attribute_dict({'bizz': 'buzz'})
+    self.assertEqual(
+        result, {
+            'bizz': 'buzz',
+            'class': budou.DEFAULT_CLASS_NAME,
+        }, 'When attributes is a dictionary but class property is not '
+        'included, the output should have the default class name in it.')
+
+    result = self.parser._get_attribute_dict({'bizz': 'buzz', 'class': 'foo'})
+    self.assertEqual(
+        result, {
+            'bizz': 'buzz',
+            'class': 'foo',
+        }, 'When attribute is a dictionary and class property is included, '
+        'the output should have the specified class name in it.')
+
+    result = self.parser._get_attribute_dict({}, 'foo')
+    self.assertEqual(
+        result, {'class': 'foo'},
+        'When attributes is none and classname is provided, the output should '
+        'have classname as the class name.')
+
+    result = self.parser._get_attribute_dict('bar', 'foo')
+    self.assertEqual(
+        result, {'class': 'bar'},
+        'When attributes is a string and classname is provided, the output '
+        'should use the class property in attributes over classname.')
+
+    result = self.parser._get_attribute_dict({'bizz': 'buzz'}, 'foo')
+    self.assertEqual(
+        result, {
+            'bizz': 'buzz',
+            'class': 'foo',
+        }, 'When attributes is a dictionary without class property and '
+        'classname is provided, the output should have classname as the class '
+        'name.')
+
+    result = self.parser._get_attribute_dict(
+        {'bizz': 'buzz', 'class': 'bar'}, 'foo')
+    self.assertEqual(
+        result, {
+            'bizz': 'buzz',
+            'class': 'bar',
+        }, 'When attributes is a dictionary with class property and classname '
+        'is provided, the output should use the class property in attributes '
+        'over classname.')
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This change makes the output DOM attribute controllable by specifying `attributes` argument. It means that users can specify ARIA tags in order to improve the accessibility as noted in #7 .