### PR TITLE
Only put CJK chunks in span (#31)

### DIFF
--- a/budou/budou.py
+++ b/budou/budou.py
@@ -391,7 +391,10 @@ class Budou(object):
           else:
             doc.getchildren()[-1].tail += ' '
         else:
-          pass
+          if doc.text is not None:
+            # We want to preserve space in cases like "Hello 你好"
+            # But the space in " 你好" can be discard.
+            doc.text += ' '
       else:
         if chunk.has_cjk():
           ele = lxml.etree.Element('span')

--- a/budou/budou.py
+++ b/budou/budou.py
@@ -68,7 +68,10 @@ class Chunk(object):
     return self.pos == self.SPACE_POS
 
   def has_cjk(self):
-    """Checks if the word of the chunk contains CJK characters"""
+    """Checks if the word of the chunk contains CJK characters
+
+    Using range from https://github.com/nltk/nltk/blob/develop/nltk/tokenize/util.py#L149
+    """
     for char in self.word:
       if any([start <= ord(char) <= end for start, end in
           [(4352, 4607), (11904, 42191), (43072, 43135), (44032, 55215),

--- a/budou/budou.py
+++ b/budou/budou.py
@@ -67,6 +67,19 @@ class Chunk(object):
     """Checks if this is space Chunk."""
     return self.pos == self.SPACE_POS
 
+  def has_cjk(self):
+    """Checks if this contains CJK characters"""
+    i = 0
+    while i < len(self.word):
+      if any([start <= ord(self.word[i]) <= end for start, end in
+          [(4352, 4607), (11904, 42191), (43072, 43135), (44032, 55215),
+           (63744, 64255), (65072, 65103), (65381, 65500),
+           (131072, 196607)]
+          ]):
+        return True
+      i += 1
+    return False
+
   def update_word(self, word):
     """Updates the word of the chunk."""
     self.word = word
@@ -373,15 +386,30 @@ class Budou(object):
     for chunk in chunks:
       if chunk.is_space():
         if doc.getchildren():
-          doc.getchildren()[-1].tail = ' '
+          if doc.getchildren()[-1].tail is None:
+            doc.getchildren()[-1].tail = ' '
+          else:
+            doc.getchildren()[-1].tail += ' '
         else:
           pass
       else:
-        ele = lxml.etree.Element('span')
-        ele.text = chunk.word
-        for k, v in attributes.items():
-          ele.attrib[k] = v
-        doc.append(ele)
+        if chunk.has_cjk():
+          ele = lxml.etree.Element('span')
+          ele.text = chunk.word
+          for k, v in attributes.items():
+            ele.attrib[k] = v
+          doc.append(ele)
+        else:
+          if doc.getchildren():
+            if doc.getchildren()[-1].tail is None:
+              doc.getchildren()[-1].tail = chunk.word
+            else:
+              doc.getchildren()[-1].tail += chunk.word
+          else:
+            if doc.text is None:
+              doc.text = chunk.word
+            else:
+              doc.text += chunk.word
     result = lxml.etree.tostring(
         doc, pretty_print=False, encoding='utf-8').decode('utf-8')
     result = clean_html(result)

--- a/budou/budou.py
+++ b/budou/budou.py
@@ -393,7 +393,7 @@ class Budou(object):
         else:
           if doc.text is not None:
             # We want to preserve space in cases like "Hello 你好"
-            # But the space in " 你好" can be discard.
+            # But the space in " 你好" can be discarded.
             doc.text += ' '
       else:
         if chunk.has_cjk():

--- a/budou/budou.py
+++ b/budou/budou.py
@@ -68,16 +68,14 @@ class Chunk(object):
     return self.pos == self.SPACE_POS
 
   def has_cjk(self):
-    """Checks if this contains CJK characters"""
-    i = 0
-    while i < len(self.word):
-      if any([start <= ord(self.word[i]) <= end for start, end in
+    """Checks if the word of the chunk contains CJK characters"""
+    for char in self.word:
+      if any([start <= ord(char) <= end for start, end in
           [(4352, 4607), (11904, 42191), (43072, 43135), (44032, 55215),
            (63744, 64255), (65072, 65103), (65381, 65500),
            (131072, 196607)]
           ]):
         return True
-      i += 1
     return False
 
   def update_word(self, word):
@@ -403,6 +401,8 @@ class Budou(object):
             ele.attrib[k] = v
           doc.append(ele)
         else:
+          # add word without span tag for non-CJK text (e.g. English)
+          # by appending it after the last element
           if doc.getchildren():
             if doc.getchildren()[-1].tail is None:
               doc.getchildren()[-1].tail = chunk.word

--- a/test/budou_test.py
+++ b/test/budou_test.py
@@ -260,16 +260,17 @@ class TestBudouMethods(unittest.TestCase):
 
   def test_html_serialize(self):
     chunks = budou.ChunkList([
-        budou.Chunk('a'), budou.Chunk('b'), budou.Chunk.space(),
-        budou.Chunk('c')])
+        budou.Chunk('Hello'), budou.Chunk.space(), budou.Chunk(u'今天'),
+        budou.Chunk(u'天气'), budou.Chunk(u'很好')])
     attributes = {
         'class': 'foo'
     }
     expected = (
         '<span>'
-        '<span class="foo">a</span>'
-        '<span class="foo">b</span> '
-        '<span class="foo">c</span>'
+        'Hello '
+        u'<span class="foo">今天</span>'
+        u'<span class="foo">天气</span>' 
+        u'<span class="foo">很好</span>'
         '</span>')
     result = self.parser._html_serialize(chunks, attributes)
     self.assertEqual(


### PR DESCRIPTION
This pull request addresses issue #31.

```
>>> import budou
>>> parser = budou.authenticate('/Users/adamyi/credential.json')
>>> result = parser.parse(u'Let us test this fun 今日も元気です tool!', attributes={'class': 'wordwrap'}, language='ja')
>>> print(result['html_code'])
<span>Let us test this fun <span class="wordwrap">今日も</span><span class="wordwrap">元気です </span>tool!</span>
```