### PR TITLE
Make sure output is utf-8 encoded

### DIFF
--- a/budou/budou.py
+++ b/budou/budou.py
@@ -67,7 +67,7 @@ def main():
       inlinestyle=args['--inlinestyle'],
       wbr=args['--wbr'],
       )
-  print(result['html_code'])
+  print(result['html_code'].encode('utf-8'))
   sys.exit()
 
 def parse(source, segmenter='nlapi', language=None, max_length=None,


### PR DESCRIPTION
Otherwise, you cannot send stdout to any other process or file without running into the error
`UnicodeEncodeError: 'ascii' codec can't encode characters in position 23-25: ordinal not in range(128)`