### PR TITLE
Make the output print Python 3 friendly

### DIFF
--- a/budou/budou.py
+++ b/budou/budou.py
@@ -67,7 +67,10 @@ def main():
       inlinestyle=args['--inlinestyle'],
       wbr=args['--wbr'],
       )
-  print(result['html_code'].encode('utf-8'))
+  html_code = result['html_code']
+  if not isinstance(html_code, str):
+    html_code = html_code.encode('utf-8')
+  print(html_code)
   sys.exit()
 
 def parse(source, segmenter='nlapi', language=None, max_length=None,


### PR DESCRIPTION
Make sure that a str (not Unicode on Python2 or bytes on Python3) is printed.